### PR TITLE
Fix linking issues and point to $DEVKITPRO tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ binary:
 	cp build/*.3dsx .
 	
 upload: binary
-	3dslink -a $(3DS_IP) nordlicht19.3dsx
+	$(DEVKITPRO)/tools/bin/3dslink -a $(3DS_IP) nordlicht19.3dsx
 	
 test: binary
 	cp nordlicht19.3dsx run.3dsx

--- a/build/Makefile
+++ b/build/Makefile
@@ -20,9 +20,9 @@ LIBS := -lcitro3d -lctru -lm
 VPATH := $(BUILD):$(SOURCES):$(DATA)
 
 # Tools
-CC := arm-none-eabi-gcc
-AS := arm-none-eabi-as
-NM := arm-none-eabi-nm
+CC := $(DEVKITARM)/bin/arm-none-eabi-gcc
+AS := $(DEVKITARM)/bin/arm-none-eabi-as
+NM := $(DEVKITARM)/bin/arm-none-eabi-nm
 LD := $(CC)
 
 # Tool flags
@@ -31,7 +31,7 @@ CFLAGS := -Wno-missing-braces -O3 \
           -std=c99 \
 	  -fomit-frame-pointer -ffunction-sections \
 	  -mfloat-abi=hard -ffast-math \
-	  $(ARCH) -DARM11 -D_3DS \
+	  $(ARCH) -D__3DS__ \
 	  -DABGR32Pixels \
 	  $(foreach dir,$(LIBDIRS),-I$(dir)/include) -I$(BUILD)
 ASFLAGS := 
@@ -73,7 +73,7 @@ clean:
 	
 # Basic "binary blob" build rule
 %.bin.o: %.bin
-	bin2s $< | $(AS) -o $(@)
+	$(DEVKITPRO)/tools/bin/bin2s $< | $(AS) -o $(@)
 	echo "extern const u8" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(<F) | tr . _)`.h
 	echo "extern const u8" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(<F) | tr . _)`.h
 	echo "extern const u32" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`_size";" >> `(echo $(<F) | tr . _)`.h
@@ -81,8 +81,8 @@ clean:
 # GPU shader assembly.
 define shader-as
 	$(eval CURBIN := $(patsubst %.shbin.o,%.shbin,$(notdir $@)))
-	picasso -o $(CURBIN) $1
-	bin2s $(CURBIN) | $(AS) -o $@
+	$(DEVKITPRO)/tools/bin/picasso -o $(CURBIN) $1
+	$(DEVKITPRO)/tools/bin/bin2s $(CURBIN) | $(AS) -o $@
 	echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(CURBIN) | tr . _)`.h
 	echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(CURBIN) | tr . _)`.h
 	echo "extern const u32" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`_size";" >> `(echo $(CURBIN) | tr . _)`.h
@@ -99,11 +99,11 @@ endef
 
 # App metainfo
 %.smdh: $(APP_ICON) $(MAKEFILE_LIST)
-	smdhtool --create "$(TARGET)" "$(DESC)" "$(AUTHOR)" $(BASEDIR)/icon.png $@
+	$(DEVKITPRO)/tools/bin/smdhtool --create "$(TARGET)" "$(DESC)" "$(AUTHOR)" $(BASEDIR)/icon.png $@
 
 # Binary from elf build rule
 %.3dsx: %.elf
-	3dsxtool $< --smdh=$(BASEDIR)build/$(TARGET).smdh --romfs=$(BASEDIR)romfs/ $(_3DSXFLAGS) $@
+	$(DEVKITPRO)/tools/bin/3dsxtool $< --smdh=$(BASEDIR)build/$(TARGET).smdh --romfs=$(BASEDIR)romfs/ $(_3DSXFLAGS) $@
 
 # Linking rule
 %.elf: 

--- a/source/EffectDance.c
+++ b/source/EffectDance.c
@@ -53,11 +53,11 @@ static vertex_rigged* vbo;
 static C3D_BufInfo* bufInfo;
 
 // Sync
-const struct sync_track* sync_zoom;
-const struct sync_track* sync_rotate;
-const struct sync_track* sync_movement;
-const struct sync_track* sync_stars;
-const struct sync_track* sync_starmax;
+static const struct sync_track* sync_zoom;
+static const struct sync_track* sync_rotate;
+static const struct sync_track* sync_movement;
+static const struct sync_track* sync_stars;
+static const struct sync_track* sync_starmax;
 
 // Stars!
 #define NUM_STARS 300

--- a/source/EffectSun.c
+++ b/source/EffectSun.c
@@ -46,13 +46,13 @@
 // }
 
 // Sync
-const struct sync_track* sync_anim_t;
-const struct sync_track* sync_anim_r;
-const struct sync_track* sync_anim_w;
-const struct sync_track* sync_anim_f;
-const struct sync_track* sync_rotate;
-const struct sync_track* sync_bright;
-const struct sync_track* sync_build;
+static const struct sync_track* sync_anim_t;
+static const struct sync_track* sync_anim_r;
+static const struct sync_track* sync_anim_w;
+static const struct sync_track* sync_anim_f;
+static const struct sync_track* sync_rotate;
+static const struct sync_track* sync_bright;
+static const struct sync_track* sync_build;
 
 // Marching cubes related
 float* marchingCubesGrid;
@@ -76,7 +76,7 @@ static int uLocModelviewSkybox;
 
 static C3D_Tex skybox_tex;
 static C3D_TexCube skybox_cube;
-int skyboxVertCount;
+static int skyboxVertCount;
 
 static C3D_Tex room_tex;
 

--- a/source/EffectSun2.c
+++ b/source/EffectSun2.c
@@ -24,7 +24,7 @@ static int uLocModelviewSkybox;
 
 static C3D_Tex skybox_tex;
 static C3D_TexCube skybox_cube;
-int skyboxVertCount;
+static int skyboxVertCount;
 
 static C3D_Tex station_tex_col;
 static C3D_Tex station_tex_norm;
@@ -55,12 +55,12 @@ static vertex2* vbo;
 static C3D_BufInfo* bufInfo;
 
 // Sync
-const struct sync_track* sync_zoom;
-const struct sync_track* sync_rotate;
-const struct sync_track* sync_rotate2;
-const struct sync_track* sync_noise;
-const struct sync_track* sync_fov;
-const struct sync_track* sync_logo;
+static const struct sync_track* sync_zoom;
+static const struct sync_track* sync_rotate;
+static const struct sync_track* sync_rotate2;
+static const struct sync_track* sync_noise;
+static const struct sync_track* sync_fov;
+static const struct sync_track* sync_logo;
 
 static C3D_Tex tex_logo1;
 static C3D_Tex tex_logo2;

--- a/source/Tools.c
+++ b/source/Tools.c
@@ -2,6 +2,8 @@
 #include "vshader_flat_shbin.h"
 #include "Perlin.h"
 
+struct sync_device *rocket;
+
 int RandomInteger() {
     return rand();
 }

--- a/source/Tools.h
+++ b/source/Tools.h
@@ -38,7 +38,7 @@
 #include "TextureHack.h"
 
 #include "Rocket/sync.h"
-struct sync_device *rocket;
+extern struct sync_device *rocket;
 
 #define SCREEN_WIDTH 400
 #define SCREEN_HEIGHT 240


### PR DESCRIPTION
Hi!

First of all, great demo! I really liked those metaballs :-)

I ran into a few minor issues when trying to build the demo with a fresh build of devkitPro, but it didn't take too long to fix. I'm sharing the fixes here. These should make the Makefiles work with the latest devkitPro. The two main issues were that tools like 3dslink/picasso/etc... are in `$DEVKITPRO/tools/bin` now. The other issue was during linking where there were multiple symbol re-definitions for `sync_rotation` and `sync_zoom` etc... the fix there was to just make them be exposed in their own compilation unit.

And yes, I'll try to make some 3DS demos, stay tuned ;-)

Happy Hacking!